### PR TITLE
Simplify Grammar to compress AST.

### DIFF
--- a/syntax.cf
+++ b/syntax.cf
@@ -8,13 +8,19 @@ token Int digit+ ;
 -- The regular expression for allowed Variable Names - tensors, or networks
 token VariableName letter (letter|digit|'_')* ;
 
+-- Sequence of integers to represent Tensor shape/indicies
+separator nonempty Int "," ;
+
+-- Production of notation for Tensor shape/indices
+TensorIndex. TensorInds ::= "[" [Int] "]" ;
+
 -- Production of Tensor Shape (empty shape is allowed for scalar tensors)
-separator Int "," ;
-Dimensions. TensorDims ::= "[" [Int] "]" ;
+ScalarDims. TensorShape ::= "[" "]" ;
+TensorDims. TensorShape ::= "[" [Int] "]" ;
 
 -- ArithExpr is a numeric value that may be a parameter, a tensor element, or an arithmetic operation
--- A variable refers to a tensor element, constructed with the associated variable name and tensor indices
-VarExpr. ArithExpr ::= VariableName TensorDims ;
+-- -- A variable refers to a tensor element, constructed with the associated variable name and tensor indices
+VarExpr. ArithExpr ::= VariableName TensorInds ;
 DoubleExpr. ArithExpr ::= SDouble ;
 SIntExpr. ArithExpr ::= SInt ;
 IntExpr. ArithExpr ::= Int ;

--- a/syntax.cf
+++ b/syntax.cf
@@ -8,18 +8,12 @@ token Int digit+ ;
 -- The regular expression for allowed Variable Names - tensors, or networks
 token VariableName letter (letter|digit|'_')* ;
 
--- Sequence of integers to represent Tensor shape/indicies
-separator nonempty Int "," ;
-
--- Production of notation for Tensor shape/indices
-TensDims. TensorDims ::= "[" [Int] "]" ; 
-
 -- Production of Tensor Shape (empty shape is allowed for scalar tensors)
-SclTensShape. TensorShape ::= "[" "]" ;
-GenTensShape. TensorShape ::= TensorDims ;
+separator Int "," ;
+Dimensions. TensorDims ::= "[" [Int] "]" ;
 
 -- ArithExpr is a numeric value that may be a parameter, a tensor element, or an arithmetic operation
--- -- A variable refers to a tensor element, constructed with the associated variable name and tensor indices
+-- A variable refers to a tensor element, constructed with the associated variable name and tensor indices
 VarExpr. ArithExpr ::= VariableName TensorDims ;
 DoubleExpr. ArithExpr ::= SDouble ;
 SIntExpr. ArithExpr ::= SInt ;
@@ -76,20 +70,19 @@ ElementTypeBool. ElementType ::= "bool" ;
 ElementTypeString. ElementType ::= "string" ;
 
 -- A tensor definition is a declaration of a tensor variable with a shape and an element type
-InputDef. InputDefinition ::= "(declare-input" VariableName ElementType TensorShape ")" ;
-HiddenDef. HiddenDefinition ::= "(declare-hidden" VariableName ElementType TensorShape String ")" ;
-OutputDef. OutputDefinition ::= "(declare-output" VariableName ElementType TensorShape ")" ;
-InputOnnxDef. InputOnnxDefinition ::= "(declare-input" VariableName ElementType TensorShape String ")" ;
-OutputOnnxDef. OutputOnnxDefinition ::= "(declare-output" VariableName ElementType TensorShape String ")" ;
+InputDef. InputDefinition ::= "(declare-input" VariableName ElementType TensorDims ")" ;
+InputOnnxDef. InputDefinition ::= "(declare-input" VariableName ElementType TensorDims String ")" ;
+
+HiddenDef. HiddenDefinition ::= "(declare-hidden" VariableName ElementType TensorDims String ")" ;
+
+OutputDef. OutputDefinition ::= "(declare-output" VariableName ElementType TensorDims ")" ;
+OutputOnnxDef. OutputDefinition ::= "(declare-output" VariableName ElementType TensorDims String ")" ;
 
 separator nonempty InputDefinition "" ;
 separator HiddenDefinition "" ;
 separator nonempty OutputDefinition "" ;
-separator nonempty InputOnnxDefinition "" ;
-separator nonempty OutputOnnxDefinition "" ;
 
 NetworkDef. NetworkDefinition ::= "(declare-network" VariableName [InputDefinition] [HiddenDefinition] [OutputDefinition] ")" ;
-NetworkOnnxDef. NetworkDefinition ::= "(declare-network" VariableName [InputOnnxDefinition] [HiddenDefinition] [OutputOnnxDefinition] ")" ;
 separator nonempty NetworkDefinition "" ;
 
 -- A query is a series of network definitions followed by a series of properties

--- a/syntax.cf
+++ b/syntax.cf
@@ -11,16 +11,13 @@ token VariableName letter (letter|digit|'_')* ;
 -- Sequence of integers to represent Tensor shape/indicies
 separator nonempty Int "," ;
 
--- Production of notation for Tensor shape/indices
-TensorIndex. TensorInds ::= "[" [Int] "]" ;
-
 -- Production of Tensor Shape (empty shape is allowed for scalar tensors)
 ScalarDims. TensorShape ::= "[" "]" ;
 TensorDims. TensorShape ::= "[" [Int] "]" ;
 
 -- ArithExpr is a numeric value that may be a parameter, a tensor element, or an arithmetic operation
 -- -- A variable refers to a tensor element, constructed with the associated variable name and tensor indices
-VarExpr. ArithExpr ::= VariableName TensorInds ;
+VarExpr. ArithExpr ::= VariableName "[" [Int] "]" ;
 DoubleExpr. ArithExpr ::= SDouble ;
 SIntExpr. ArithExpr ::= SInt ;
 IntExpr. ArithExpr ::= Int ;
@@ -76,13 +73,13 @@ ElementTypeBool. ElementType ::= "bool" ;
 ElementTypeString. ElementType ::= "string" ;
 
 -- A tensor definition is a declaration of a tensor variable with a shape and an element type
-InputDef. InputDefinition ::= "(declare-input" VariableName ElementType TensorDims ")" ;
-InputOnnxDef. InputDefinition ::= "(declare-input" VariableName ElementType TensorDims String ")" ;
+InputDef. InputDefinition ::= "(declare-input" VariableName ElementType TensorShape ")" ;
+InputOnnxDef. InputDefinition ::= "(declare-input" VariableName ElementType TensorShape String ")" ;
 
-HiddenDef. HiddenDefinition ::= "(declare-hidden" VariableName ElementType TensorDims String ")" ;
+HiddenDef. HiddenDefinition ::= "(declare-hidden" VariableName ElementType TensorShape String ")" ;
 
-OutputDef. OutputDefinition ::= "(declare-output" VariableName ElementType TensorDims ")" ;
-OutputOnnxDef. OutputDefinition ::= "(declare-output" VariableName ElementType TensorDims String ")" ;
+OutputDef. OutputDefinition ::= "(declare-output" VariableName ElementType TensorShape ")" ;
+OutputOnnxDef. OutputDefinition ::= "(declare-output" VariableName ElementType TensorShape String ")" ;
 
 separator nonempty InputDefinition "" ;
 separator HiddenDefinition "" ;


### PR DESCRIPTION
When I started updating the C parser to be congruent with the grammar updates by @developing-ar, I noticed some changes (which were discussed in your earlier PR) could be made to simplify the AST structure. These changes make the grammar less restrictive though. What do you think?

Changes:
- Compress TensorShape production into 'TensorDims' which may be an empty shape ('[]')
- Fold 'InputOnnxDefinition' and 'OutputOnnxDefinition' productions into InputDefinition and OutputDefinition.