### PR TITLE
Document semantics of Real element type + minor improvements

### DIFF
--- a/document/bibliography.bib
+++ b/document/bibliography.bib
@@ -12,3 +12,12 @@
   year={2005},
   url={https://bnfc.digitalgrammars.com/LBNF-report.pdf}
 }
+
+@inproceedings{jia2021exploiting,
+  title={Exploiting verified neural networks via floating point numerical error},
+  author={Jia, Kai and Rinard, Martin},
+  booktitle={International Static Analysis Symposium},
+  pages={191--205},
+  year={2021},
+  organization={Springer}
+}

--- a/document/chapters/logics.tex
+++ b/document/chapters/logics.tex
@@ -51,6 +51,7 @@ The currently supported theory sets are:
 The following sections examine each of these theory sets in more detail.
 
 \subsection{Hidden nodes}
+\label{sec:hidden-nodes}
 
 \begin{figure}[h]
 \centering
@@ -68,8 +69,8 @@ Some neural network verifiers do not support reasoning about hidden nodes. The `
 
 \begin{code}[style=lbnf]
 (declare-network f
-    (declare-input  X Real [1])
-    (declare-output Y Real [1])
+    (declare-input  X float [1])
+    (declare-output Y float [1])
 )
 \end{code}
 
@@ -77,13 +78,14 @@ but the following query is only a member of \h{}:
 
 \begin{code}[style=lbnf]
 (declare-network f
-    (declare-input  X Real [1])
-    (declare-hidden H Real [1])
-    (declare-output Y Real [1])
+    (declare-input  X float [1])
+    (declare-hidden H float [1])
+    (declare-output Y float [1])
 )
 \end{code}
 
 \subsection{Multiple networks}
+\label{sec:multiple-networks}
 
 \begin{figure}[h]
 \centering
@@ -101,8 +103,8 @@ Many neural network verifiers only support reasoning about a single network. The
 
 \begin{code}[style=lbnf]
 (declare-network f
-    (declare-input  X Real [1])
-    (declare-output Y Real [1])
+    (declare-input  X float [1])
+    (declare-output Y float [1])
 )
 \end{code}
 
@@ -110,16 +112,17 @@ but the following query is only a member of \mnet{}:
 
 \begin{code}[style=lbnf]
 (declare-network f
-    (declare-input  X Real [1])
-    (declare-output Y Real [1])
+    (declare-input  X float [1])
+    (declare-output Y float [1])
 )
 (declare-network g
-    (declare-input  U Real [1])
-    (declare-output W Real [1])
+    (declare-input  U float [1])
+    (declare-output W float [1])
 )
 \end{code}
 
 \subsection{Multiple inputs/output}
+\label{sec:multiple-inputs-outputs}
 
 \begin{figure}[h]
 \centering
@@ -137,8 +140,8 @@ Many neural network verifiers only support reasoning about networks with a singl
 
 \begin{code}[style=lbnf]
 (declare-network f
-    (declare-input  X Real [1])
-    (declare-output Y Real [1])
+    (declare-input  X float [1])
+    (declare-output Y float [1])
 )
 \end{code}
 
@@ -146,13 +149,14 @@ but the following query is only a member of \mio{}:
 
 \begin{code}[style=lbnf]
 (declare-network f
-    (declare-input  X1 Real [1])
-    (declare-input  X2 Real [1])
-    (declare-output Y  Real [1])
+    (declare-input  X1 float [1])
+    (declare-input  X2 float [1])
+    (declare-output Y  float [1])
 )
 \end{code}
 
-\subsection{Multi-node comparisons}\label{sec:arch}
+\subsection{Multiple node comparisons}
+\label{sec:multi-node-comparisons}
 
 \begin{figure}[h]
 \centering
@@ -162,25 +166,25 @@ but the following query is only a member of \mio{}:
 
    \draw [arrow] (snc) -- (mnc);
 \end{tikzpicture}
-\caption{The ``Multi-node comparisons'' theory set}
+\caption{The ``Multiple node comparisons'' theory set}
 \label{fig:multi-node-comparisons-theory-set}
 \end{figure}
 
 Many verifiers are based on some variant of abstract interpretation or reachability analysis where an over-approximation of the set of reachable values is computed for each layer in turn.
 One consequence of this is that they cannot easily verify queries that contain a comparison involving variables from different nodes in the same network.
 
-The ``Multi-node comparisons'' theory set therefore contains two theories \snc{} and \mnc{}, representing queries that contain comparisons that do not reference variables from different nodes of the same network, and queries that may contain such comparisons respectively. Therefore \snc{} is a subset of \mnc{}. For example, consider queries that declare the following networks:
+The ``Multiple node comparisons'' theory set therefore contains two theories \snc{} and \mnc{}, representing queries that contain comparisons that do not reference variables from different nodes of the same network, and queries that may contain such comparisons respectively. Therefore \snc{} is a subset of \mnc{}. For example, consider queries that declare the following networks:
 
 \begin{code}[style=lbnf]
 (declare-network f
-    (declare-input  X Real [2])
-    (declare-output Y Real [1])
+    (declare-input  X float [2])
+    (declare-output Y float [1])
 )
 
 (declare-network g
-    (declare-input  A Real [2])
-    (declare-hidden H Real [1])
-    (declare-output B Real [1])
+    (declare-input  A float [2])
+    (declare-hidden H float [1])
+    (declare-output B float [1])
 )
 \end{code}
 
@@ -204,6 +208,7 @@ However, the following comparisons only belong to \mnc{}:
 \end{code}
 
 \subsection{Arithmetic complexity}
+\label{sec:arithmetic-complexity}
 
 \begin{figure}[h]
 \centering
@@ -248,9 +253,10 @@ For example, the following assertion belongs in \poly{} but not in \lin{}
 \end{enumerate}
 
 
+\subsection{Element types}
+\label{sec:element-types}
 
-\subsection{Datatypes}
-
+\subsubsection{ONNX element types}
 
 \begin{figure}[h]
 \centering
@@ -284,19 +290,23 @@ For example, the following assertion belongs in \poly{} but not in \lin{}
 
 As discussed in Section~\ref{sec:onnx_overview}, the ONNX format supports a range of different datatypes such \theory{FLOAT} (32-bit floats), \theory{FLOAT16} (16-bit floats), \theory{INT64} (64-bit integers), \theory{BOOL} among many others. Most verifiers will support a particular precision of floating point, or assume real number semantics. 
 
-Therefore every datatype in the ONNX \href{https://onnx.ai/onnx/intro/concepts.html#element-type}{specification} is associated with a \vnnlib{} theory of the same name. A solver supporting a particular datatype theory means that it supports variable declarations that use that datatype. For example, the following network declaration belongs to the \theory{FLOAT16} theory:
+Therefore every element type in the ONNX \href{https://onnx.ai/onnx/intro/concepts.html#element-type}{specification} is associated with a \vnnlib{} theory of the same name. A solver supporting a particular element type theory means that it supports variable declarations that use that type. For example, the following network declaration belongs to the \theory{float16} theory:
 
 \begin{code}[style=lbnf]
 (declare-network f
-    (declare-input  X FLOAT16 [2])
-    (declare-output Y FLOAT16 [1])
+    (declare-input  X float16 [2])
+    (declare-output Y float16 [1])
 )
 \end{code}
 
-In addition to the supported ONNX datatypes, many verifiers assume real number semantics while performing verification. Although assuming neural networks operate over real numbers is well known to compromise the soundness of verification, it is important for trust in the field that verifiers accurately report their assumptions. Therefore, the VNNLib standard also supports an additional datatype theory \theory{Real} to provide compatability in this case.  There is no inclusion relation between any datatype theories.
-\mnote{Double check?}
+The same network can contain inputs and outputs of different ONNX element types. In such a case, the query is only supported if the solver supports all the types and the operators used internally to convert between the types.
 
-\mnote{What about network declarations that mix datatypes?}
+
+\subsubsection{The `Real' element type}
+
+It is a well-known problem in the community that some solvers assume real semantics and therefore are not sound with respect to the semantics of the various floating point types. In order to support such solvers, the specification contains an additional element type `real` that is not in the ONNX specification.
+
+If a user uses the `real` type in their query then they are explicitly giving permission for the solver to use non-sound semantics when reasoning about the network. Conversely if the query uses ONNX element types then the user is explicitly requesting sound analysis. Therefore if the solver does not support the ONNX element types in question, then the solver must error. Likewise if the types used in the actual network provided to the solver do not match the types in the query, the solver must also error.
 
 \section{Logics}
 

--- a/document/chapters/logics.tex
+++ b/document/chapters/logics.tex
@@ -69,8 +69,8 @@ Some neural network verifiers do not support reasoning about hidden nodes. The `
 
 \begin{code}[style=lbnf]
 (declare-network f
-    (declare-input  X float [1])
-    (declare-output Y float [1])
+    (declare-input  X float32 [1])
+    (declare-output Y float32 [1])
 )
 \end{code}
 
@@ -78,9 +78,9 @@ but the following query is only a member of \h{}:
 
 \begin{code}[style=lbnf]
 (declare-network f
-    (declare-input  X float [1])
-    (declare-hidden H float [1])
-    (declare-output Y float [1])
+    (declare-input  X float32 [1])
+    (declare-hidden H float32 [1])
+    (declare-output Y float32 [1])
 )
 \end{code}
 
@@ -103,8 +103,8 @@ Many neural network verifiers only support reasoning about a single network. The
 
 \begin{code}[style=lbnf]
 (declare-network f
-    (declare-input  X float [1])
-    (declare-output Y float [1])
+    (declare-input  X float32 [1])
+    (declare-output Y float32 [1])
 )
 \end{code}
 
@@ -112,12 +112,12 @@ but the following query is only a member of \mnet{}:
 
 \begin{code}[style=lbnf]
 (declare-network f
-    (declare-input  X float [1])
-    (declare-output Y float [1])
+    (declare-input  X float32 [1])
+    (declare-output Y float32 [1])
 )
 (declare-network g
-    (declare-input  U float [1])
-    (declare-output W float [1])
+    (declare-input  U float32 [1])
+    (declare-output W float32 [1])
 )
 \end{code}
 
@@ -140,8 +140,8 @@ Many neural network verifiers only support reasoning about networks with a singl
 
 \begin{code}[style=lbnf]
 (declare-network f
-    (declare-input  X float [1])
-    (declare-output Y float [1])
+    (declare-input  X float32 [1])
+    (declare-output Y float32 [1])
 )
 \end{code}
 
@@ -149,9 +149,9 @@ but the following query is only a member of \mio{}:
 
 \begin{code}[style=lbnf]
 (declare-network f
-    (declare-input  X1 float [1])
-    (declare-input  X2 float [1])
-    (declare-output Y  float [1])
+    (declare-input  X1 float32 [1])
+    (declare-input  X2 float32 [1])
+    (declare-output Y  float32 [1])
 )
 \end{code}
 
@@ -177,14 +177,14 @@ The ``Multiple node comparisons'' theory set therefore contains two theories \sn
 
 \begin{code}[style=lbnf]
 (declare-network f
-    (declare-input  X float [2])
-    (declare-output Y float [1])
+    (declare-input  X float32 [2])
+    (declare-output Y float32 [1])
 )
 
 (declare-network g
-    (declare-input  A float [2])
-    (declare-hidden H float [1])
-    (declare-output B float [1])
+    (declare-input  A float32 [2])
+    (declare-hidden H float32 [1])
+    (declare-output B float32 [1])
 )
 \end{code}
 
@@ -253,7 +253,7 @@ For example, the following assertion belongs in \poly{} but not in \lin{}
 \end{enumerate}
 
 
-\subsection{Element types}
+\subsection{Tensor element types}
 \label{sec:element-types}
 
 \subsubsection{ONNX element types}
@@ -261,36 +261,30 @@ For example, the following assertion belongs in \poly{} but not in \lin{}
 \begin{figure}[h]
 \centering
 \begin{tikzpicture}    
-    \node (onnx) [category] at (-2,0) {ONNX defined \\ datatypes};
+    \node (onnx) [category] at (-2,0) {ONNX element types};
     
-    \draw [dashed] (3.3,0.5) -- (3.3,-11);
+    \draw [dashed] (1.3,0.5) -- (1.3,-8);
     
-    \node (other) [category] at (5,0) {Additional \\ datatypes};
+    \node (other) [category] at (5,0) {Additional element types};
     
     
-   \node (d)   [theory, below=of onnx, xshift=-2cm]  {\theory{DOUBLE} \\ (64-bit floats)};
-   \node (f)   [theory, below=of d]  {\theory{FLOAT} \\ (32-bit floats)};
-   \node (f16)   [theory, below=of f]  {\theory{FLOAT16} \\ (16-bit floats)};
+   \node (d)   [theory, below=of onnx, xshift=-1.5cm]  {\theory{FLOAT64}};
+   \node (f)   [theory, below=of d]  {\theory{FLOAT32}};
+   \node (f16)   [theory, below=of f]  {\theory{FLOAT16}};
    \node (dots1)   [below=of f16]  {\textbf{...}};
-   \node (bool)   [theory, below=of dots1]  {\theory{BOOL} \\ (booleans)};
-   \node (dots3)   [below=of bool]  {\textbf{...}};
    
-  \node (i64)   [theory, below=of onnx, xshift=2cm]  {\theory{INT64} \\ (64-bit integers)};
-   \node (i32)   [theory, below=of i64]  {\theory{INT32} \\ (32-bit integers)};
-   \node (i16)   [theory, below=of i32]  {\theory{INT16} \\ (16-bit integers)};
+  \node (i64)   [theory, below=of onnx, xshift=1.5cm]  {\theory{INT64}};
+   \node (i32)   [theory, below=of i64]  {\theory{INT32}};
+   \node (i16)   [theory, below=of i32]  {\theory{INT16}};
    \node (dots2)   [below=of i16]  {\textbf{...}};
-   \node (uint4)   [theory, below=of dots2]  {\theory{UINT4} \\ (4-bit unsigned integers)};
-   \node (dots4)   [below=of uint4]  {\textbf{...}};
    
-   \node (real)        [theory, below=of other] {R \\ (Real)};
+   \node (real)        [theory, below=of other] {REAL};
 \end{tikzpicture}
-\caption{The ``Datatypes'' theory set. Not all ONNX defined datatypes are shown.}
-\label{fig:vnnlib_capabilities}
+\caption{The ``Tensor element types'' theory set. Not all ONNX defined datatypes are shown.}
+\label{fig:element-type-theories}
 \end{figure}
 
-As discussed in Section~\ref{sec:onnx_overview}, the ONNX format supports a range of different datatypes such \theory{FLOAT} (32-bit floats), \theory{FLOAT16} (16-bit floats), \theory{INT64} (64-bit integers), \theory{BOOL} among many others. Most verifiers will support a particular precision of floating point, or assume real number semantics. 
-
-Therefore every element type in the ONNX \href{https://onnx.ai/onnx/intro/concepts.html#element-type}{specification} is associated with a \vnnlib{} theory of the same name. A solver supporting a particular element type theory means that it supports variable declarations that use that type. For example, the following network declaration belongs to the \theory{float16} theory:
+As discussed in Section~\ref{sec:onnx_overview} and as seen in Figure~\ref{fig:element-type-theories}, the ONNX format supports a range of different tensor element types such ``float32''. Every tensor element type in the ONNX \href{https://onnx.ai/onnx/repo-docs/IR.html#tensor-element-types}{specification} is associated with a \vnnlib{} theory of the same name. A solver supporting a particular element type theory means that it supports variable declarations that use that type. For example, the following network declaration belongs to the \theory{float16} theory:
 
 \begin{code}[style=lbnf]
 (declare-network f
@@ -299,15 +293,18 @@ Therefore every element type in the ONNX \href{https://onnx.ai/onnx/intro/concep
 )
 \end{code}
 
-The same network can contain inputs and outputs of different ONNX element types. In such a case, the query is only supported if the solver supports all the types and the operators used internally to convert between the types.
+Of course, the same network declaration can contain inputs and outputs of different ONNX element types. In such a case, the query is only supported if the solver supports all of the theories associated with the element types (and of course the ONNX operators used internally to convert between the types).
 
+\textbf{Note}: the ONNX specification has two different sets of names for the element types: \href{https://onnx.ai/onnx/repo-docs/IR.html#tensor-element-types}{Set 1} and \href{https://onnx.ai/onnx/intro/concepts.html#element-type}{Set 2}. \vnnlib{} uses the former set of names.
 
 \subsubsection{The `Real' element type}
 
-It is a well-known problem in the community that some solvers assume real semantics and therefore are not sound with respect to the semantics of the various floating point types. In order to support such solvers, the specification contains an additional element type `real` that is not in the ONNX specification.
+It is a well-known problem in the community that some solvers assume real semantics and therefore are not sound with respect to the semantics of the various floating point types~\cite{jia2021exploiting}. In order to support such solvers, the specification contains an additional tensor element type `real` and associated theory that does not appear in the ONNX specification.
 
-If a user uses the `real` type in their query then they are explicitly giving permission for the solver to use non-sound semantics when reasoning about the network. Conversely if the query uses ONNX element types then the user is explicitly requesting sound analysis. Therefore if the solver does not support the ONNX element types in question, then the solver must error. Likewise if the types used in the actual network provided to the solver do not match the types in the query, the solver must also error.
+If a user writes the ``real'' type in their \vnnlib{} query then they are explicitly giving permission for the solver to convert the numeric ONNX types used by the actual ONNX file to an arbitrary internal numeric representation. The user is therefore explicitly acknowledging that the result may be unsound due to floating point imprecision. 
+
+Conversely if user writes an ONNX element type in their \vnnlib{} query then they are explicitly requesting sound analysis. If the solver does not support the ONNX element type in question, then the solver must throw an error. The solver must also throw an error if the types used in the ONNX network provided do not match the ONNX element types written in the query.
 
 \section{Logics}
 
-Logics are therefore composed by the combination of theories from each of the above orthogonal categories. For example, the logic \logic{\h{}-\snet{}-\sio{}-\mnc{}-\lin{}-\theory{FLOAT}} represents the class of queries that contain hidden nodes declarations, a single network declaration with a single input and output using the 32-bit floats, with linear comparisons between arbitrary declared variables.
+Logics are therefore composed by the combination of theories from each of the above orthogonal categories. For example, the logic \logic{\h{}-\snet{}-\sio{}-\mnc{}-\lin{}-\theory{FLOAT32}} represents the class of queries that contain hidden nodes declarations, a single network declaration with a single input and output using the 32-bit floats, with linear comparisons between arbitrary declared variables.

--- a/document/chapters/logics.tex
+++ b/document/chapters/logics.tex
@@ -280,11 +280,11 @@ For example, the following assertion belongs in \poly{} but not in \lin{}
    
    \node (real)        [theory, below=of other] {REAL};
 \end{tikzpicture}
-\caption{The ``Tensor element types'' theory set. Not all ONNX defined datatypes are shown.}
+\caption{The ``Tensor element types'' theory set. Not all ONNX element types are shown.}
 \label{fig:element-type-theories}
 \end{figure}
 
-As discussed in Section~\ref{sec:onnx_overview} and as seen in Figure~\ref{fig:element-type-theories}, the ONNX format supports a range of different tensor element types such ``float32''. Every tensor element type in the ONNX \href{https://onnx.ai/onnx/repo-docs/IR.html#tensor-element-types}{specification} is associated with a \vnnlib{} theory of the same name. A solver supporting a particular element type theory means that it supports variable declarations that use that type. For example, the following network declaration belongs to the \theory{float16} theory:
+As discussed in Section~\ref{sec:onnx_overview} and as seen in Figure~\ref{fig:element-type-theories}, the ONNX format supports a range of different \href{https://onnx.ai/onnx/repo-docs/IR.html#tensor-element-types}{tensor element types} such ``float32''. Every tensor element type in the ONNX specification is associated with a \vnnlib{} theory of the same name. A solver supporting a particular element type theory means that it supports variable declarations that use that type. For example, the following network declaration belongs to the \theory{float16} theory:
 
 \begin{code}[style=lbnf]
 (declare-network f

--- a/document/chapters/models.tex
+++ b/document/chapters/models.tex
@@ -37,9 +37,8 @@ An ONNX model is serialised as a single binary file with the `.onnx' file extens
 \paragraph{Tensors}
 All tensors processed by ONNX models are strongly typed. The basic properties of an ONNX tensor include:
 \begin{itemize}
-	\item \textbf{Element Type}: ONNX defines a \href{https://onnx.ai/onnx/intro/concepts.html#element-type}{standard set of types}. 
-	The most commonly used types for neural network verification are: 32-bit floating point (FLOAT), and 16-bit floating point (FLOAT16). Signed and unsigned integers (e.g., INT32, UINT8) are also supported, 
-	but less common in neural networks.
+	\item \textbf{Element Type}: ONNX defines a \href{https://onnx.ai/onnx/repo-docs/IR.html#tensor-element-types}{standard set of types}. 
+	The most commonly used types for neural network verification are: 32-bit floating point (float32), and 16-bit floating point (float16). Signed and unsigned integers (e.g., int32, uint8) are also supported, but are less commonly used.
 	\item \textbf{Shape}: The shape of a tensor is defined as a list of integers, where each integer represents the size of the corresponding dimension. For example, a tensor with shape [3, 224, 224] 
 	represents an image with 3 color channels (RGB) and dimensions 224x224 pixels.
 	\item \textbf{Values}: A contiguous block of memory containing the actual data.

--- a/document/chapters/query_language.tex
+++ b/document/chapters/query_language.tex
@@ -16,13 +16,13 @@ Firstly, all \vnnlib{} queries are split into two parts: a list of network decla
 \label{sec:network-declarations}
 
  At its simplest, a network is introduced by the keyword \texttt{declare-network}, followed by a user-defined name for the network, and then declarations for its associated input and output. An input is declared using the \texttt{declare-input} keyword, followed by a variable name, its element type (e.g., \texttt{Real}, \texttt{float64}), 
-and the shape of the tensor. Similarly, an output variable uses the \texttt{declare-output} keyword. In the case of Figure~\ref{fig:simple-query}, the network is named \texttt{myNetwork}, and it has one input called \texttt{X} consisting of a $1 \times 10$ tensor of real numbers and one output called \texttt{Y} consisting of a $1 \times 2$ tensor of real numbers. 
+and the shape of the tensor. Similarly, an output variable uses the \texttt{declare-output} keyword. In the case of Figure~\ref{fig:simple-query}, the network is named \texttt{myNetwork}, and it has one input called \texttt{X} consisting of a $1 \times 10$ tensor of the ONNX ``float'' type (32-bit floats) and one output called \texttt{Y} consisting of a $1 \times 2$ tensor of floats. 
 \begin{figure}[t]
     \begin{minipage}[c]{0.6\textwidth}
         \begin{lstlisting}[style=lbnf]
 (declare-network myNetwork
-    (declare-input  X Real [1,10])
-    (declare-output Y Real [1,2])
+    (declare-input  X float [1,10])
+    (declare-output Y float [1,2])
 )
 
 (assert (>= X[0,2] 0.0))
@@ -103,18 +103,18 @@ The query language supports such networks by allowing a network declaration to d
     \centering
     \begin{lstlisting}[style=lbnf]
 (declare-network multi_io_net
-    (declare-input  image    Real [1,3,224,224])
-    (declare-input  metadata Real [1,10])
-    (declare-output bbox     Real [1 4])
-    (declare-output logits   Real [1,1000])
+    (declare-input  image    float [1,3,224,224])
+    (declare-input  metadata float [1,10])
+    (declare-output bbox     int16 [1 4])
+    (declare-output logits   float [1,1000])
 )\end{lstlisting}
 
     \begin{lstlisting}[style=lbnf]
 (declare-network multi_io_net
-    (declare-input  metadata Real [1,10]        "metadata")
-    (declare-input  image    Real [1,3,224,224] "image")
-    (declare-output logits   Real [1,1000]      "logits")
-    (declare-output bbox     Real [1,4,2]       "bbox")
+    (declare-input  metadata float [1,10]        "metadata")
+    (declare-input  image    float [1,3,224,224] "image")
+    (declare-output logits   float [1,1000]      "logits")
+    (declare-output bbox     int16 [1,4,2]       "bbox")
 )\end{lstlisting}
 
     \vspace{0.5cm}
@@ -132,15 +132,15 @@ In some use cases it is desirable to constrain the result of intermediate comput
 The hidden node declaration crucially refers to the uniquely identified outputs of a node, rather than the node (or operator) itself. It declares that an output of the node is to be used as a variable in the \vnnlib{} query.
 
 \begin{figure}[h!]
-    \begin{minipage}[c]{0.72\textwidth}
+    \begin{minipage}[c]{0.76\textwidth}
         \begin{lstlisting}[style=lbnf]   
 (declare-network encoder
-    (declare-input  X Real [1,28,28])
-    (declare-hidden Z Real [1,128] "hidden")
-    (declare-output Y Real [1,10])
+    (declare-input  X double [1,28,28])
+    (declare-hidden Z double [1,128] "hidden")
+    (declare-output Y double [1,10])
 )\end{lstlisting}
     \end{minipage}%
-    \begin{minipage}[c]{0.25\textwidth}
+    \begin{minipage}[c]{0.21\textwidth}
         \centering
         \includegraphics[height=6cm]{imgs/encoder_net.onnx.png}
     \end{minipage}
@@ -156,19 +156,19 @@ Often you may want to relate the behaviour of one neural network to that of anot
 shows an example which declares two networks representing a teacher and a student network.
 
 \begin{figure}[h!]
-    \begin{minipage}[c]{0.6\textwidth}
+    \begin{minipage}[c]{0.64\textwidth}
         \begin{lstlisting}[style=lbnf]
 (declare-network teacher
-    (declare-input  tX Real [1,32])
-    (declare-output tY Real [1,2])
+    (declare-input  tX float [1,32])
+    (declare-output tY float [1,2])
 )
 
 (declare-network student
-    (declare-input  sX Real [1,32])
-    (declare-output sY Real [1,2])
+    (declare-input  sX float16 [1,32])
+    (declare-output sY float16 [1,2])
 )\end{lstlisting}
     \end{minipage}
-    \begin{minipage}[c]{0.4\textwidth}
+    \begin{minipage}[c]{0.35\textwidth}
         \centering
         \includegraphics[height=7cm]{imgs/teacher_net.onnx.png}
         \vspace{0.5cm} 

--- a/document/chapters/query_language.tex
+++ b/document/chapters/query_language.tex
@@ -18,22 +18,22 @@ Firstly, all \vnnlib{} queries are split into two parts: a list of network decla
  At its simplest, a network is introduced by the keyword \texttt{declare-network}, followed by a user-defined name for the network, and then declarations for its associated input and output. An input is declared using the \texttt{declare-input} keyword, followed by a variable name, its element type (e.g., \texttt{Real}, \texttt{float64}), 
 and the shape of the tensor. Similarly, an output variable uses the \texttt{declare-output} keyword. In the case of Figure~\ref{fig:simple-query}, the network is named \texttt{myNetwork}, and it has one input called \texttt{X} consisting of a $1 \times 10$ tensor of the ONNX ``float'' type (32-bit floats) and one output called \texttt{Y} consisting of a $1 \times 2$ tensor of floats. 
 \begin{figure}[t]
-    \begin{minipage}[c]{0.6\textwidth}
+    \begin{minipage}[c]{0.62\textwidth}
         \begin{lstlisting}[style=lbnf]
 (declare-network myNetwork
-    (declare-input  X float [1,10])
-    (declare-output Y float [1,2])
+    (declare-input  X float32 [1,10])
+    (declare-output Y float32 [1,2])
 )
 
 (assert (>= X[0,2] 0.0))
 (assert (<= X[0,2] 1.0))
 (assert (<= Y[0,1] 0.5))\end{lstlisting}
     \end{minipage}%
-    \begin{minipage}[c]{0.45\textwidth}
+    \begin{minipage}[c]{0.35\textwidth}
         \centering
         \includegraphics[height=5cm]{imgs/simple_net.onnx.png}
     \end{minipage}
-    \caption{A simple \vnnlib{} specification which declares a network with a single input and output. An example of one of the many possible ONNX models compatible with this declaration is shown on the right. Note that the variable names in the declared inputs and outputs do not have to match the node names in the ONNX file.}
+    \caption{A simple \vnnlib{} specification which declares a network with a single input and output tensor. An example of one of the many possible ONNX models compatible with this declaration is shown on the right. Note that the variable names in the declared inputs and outputs do not have to match the node names in the ONNX file.}
     \label{fig:simple-query}
 \end{figure}
 
@@ -103,18 +103,18 @@ The query language supports such networks by allowing a network declaration to d
     \centering
     \begin{lstlisting}[style=lbnf]
 (declare-network multi_io_net
-    (declare-input  image    float [1,3,224,224])
-    (declare-input  metadata float [1,10])
-    (declare-output bbox     int16 [1 4])
-    (declare-output logits   float [1,1000])
+    (declare-input  image    float32 [1,3,224,224])
+    (declare-input  metadata float32 [1,10])
+    (declare-output bbox     int16   [1 4])
+    (declare-output logits   float32 [1,1000])
 )\end{lstlisting}
 
     \begin{lstlisting}[style=lbnf]
 (declare-network multi_io_net
-    (declare-input  metadata float [1,10]        "metadata")
-    (declare-input  image    float [1,3,224,224] "image")
-    (declare-output logits   float [1,1000]      "logits")
-    (declare-output bbox     int16 [1,4,2]       "bbox")
+    (declare-input  metadata float32 [1,10]        "metadata")
+    (declare-input  image    float32 [1,3,224,224] "image")
+    (declare-output logits   float32 [1,1000]      "logits")
+    (declare-output bbox     int16   [1,4,2]       "bbox")
 )\end{lstlisting}
 
     \vspace{0.5cm}
@@ -135,9 +135,9 @@ The hidden node declaration crucially refers to the uniquely identified outputs 
     \begin{minipage}[c]{0.76\textwidth}
         \begin{lstlisting}[style=lbnf]   
 (declare-network encoder
-    (declare-input  X double [1,28,28])
-    (declare-hidden Z double [1,128] "hidden")
-    (declare-output Y double [1,10])
+    (declare-input  X float64 [1,28,28])
+    (declare-hidden Z float64 [1,128] "hidden")
+    (declare-output Y float64 [1,10])
 )\end{lstlisting}
     \end{minipage}%
     \begin{minipage}[c]{0.21\textwidth}
@@ -159,8 +159,8 @@ shows an example which declares two networks representing a teacher and a studen
     \begin{minipage}[c]{0.64\textwidth}
         \begin{lstlisting}[style=lbnf]
 (declare-network teacher
-    (declare-input  tX float [1,32])
-    (declare-output tY float [1,2])
+    (declare-input  tX float32 [1,32])
+    (declare-output tY float32 [1,2])
 )
 
 (declare-network student

--- a/document/chapters/verifier_interface.tex
+++ b/document/chapters/verifier_interface.tex
@@ -174,13 +174,15 @@ and the verifier should be able to report the following capabilities:
 
 \clOutputOption
 {--onnx-types}
-{Prints a newline-separated list of the ONNX data types that the verifier supports.}
+{Prints a newline-separated list of the element types that the verifier supports. See Section~\ref{sec:element-types} for details.}
 {List of ONNX types}
 \begin{lstlisting}[style=bash]
 %*\exampleVerifier* supports --onnx-types
-REAL
-FLOAT32
+real
+float
+float16
 \end{lstlisting}
+\textbf{Note}: as discussed in Section~\ref{sec:element-types}, if a solver reports that it supports an ONNX element type then there must be a strong reason to believe that the solver's analysis is sound with respect to that type. If it is not sound, or its soundness is unknown then the solver should report that it supports the `real' type.
 
 \clOutputOption
 {--onnx-operators}
@@ -199,7 +201,7 @@ Flatten
 
 \clOutputOption
 {--multiple-input-outputs}
-{Does the verifier support ONNX networks with multiple input or output nodes? See Section~\ref{sec:complex-networks-decls} for details.}
+{Does the verifier support ONNX networks with multiple input or output nodes? See Section~\ref{sec:multiple-inputs-outputs} for details.}
 {A boolean (\texttt{true} or \texttt{false})}
 \begin{lstlisting}[style=bash]
 %*\exampleVerifier* supports --multiple-inputs-outputs
@@ -209,17 +211,8 @@ true
 \subsection{Query capabilities}
 
 \clOutputOption
-{--multiple-networks}
-{Does the verifier support queries with multiple networks? See Section~\ref{sec:complex-networks-decls} for how to declare multiple networks in a query.}
-{A boolean (\texttt{true} or \texttt{false})}
-\begin{lstlisting}[style=bash]
-%*\exampleVerifier* supports --multiple-networks
-false
-\end{lstlisting}
-
-\clOutputOption
 {--hidden-nodes}
-{Does the verifier support queries which refer to hidden nodes in the network? See Section~\ref{sec:complex-networks-decls} for how to declare hidden nodes in a query.}
+{Does the verifier support queries which refer to hidden nodes in the network? See Section~\ref{sec:hidden-nodes} for details.}
 {A boolean (\texttt{true} or \texttt{false})}
 \begin{lstlisting}[style=bash]
 %*\exampleVerifier* supports --hidden-nodes
@@ -227,9 +220,26 @@ true
 \end{lstlisting}
 
 \clOutputOption
+{--multiple-networks}
+{Does the verifier support queries with multiple networks? See Section~\ref{sec:multiple-networks} for details.}
+{A boolean (\texttt{true} or \texttt{false})}
+\begin{lstlisting}[style=bash]
+%*\exampleVerifier* supports --multiple-networks
+false
+\end{lstlisting}
+
+\clOutputOption
+{--multiple-node-comparisons}
+{Does the verifier support comparisons between variables representing different nodes in the same network? See Section~\ref{sec:multi-node-comparisons} for details.}
+{A boolean (\texttt{true} or \texttt{false})}
+\begin{lstlisting}[style=bash]
+%*\exampleVerifier* supports --multiple-node-comparisons
+true
+\end{lstlisting}
+
+\clOutputOption
 {--arithmetic-complexity}
-{Prints a list of supported \vnnlib{} logics, indicating the scope of theoretical support. See Section~\ref{sec:query_categories} for 
-    details on each of the logics (e.g., NRA for non-linear real arithmetic support) that may be represented in \vnnlib{}.
+{Prints a list of supported \vnnlib{} logics, indicating the scope of theoretical support. See Section~\ref{sec:arithmetic-complexity} for details.
 }
 {A newline-seperated list of logics.}
 \begin{lstlisting}[style=bash]

--- a/document/chapters/verifier_interface.tex
+++ b/document/chapters/verifier_interface.tex
@@ -104,14 +104,14 @@ sat
 The variables should be reported in the order that they are declared in the query file. For example, the result for a \vnnlib{} query that started with the following network declarations:
 \begin{lstlisting}[style=bash]
 (declare-network f
-    (declare-input A Real [2,2])
-    (declare-input B Real [1])
-    (declare-hidden H Real [1,2])
-    (declare-output Y Real [1])
+    (declare-input  A float32 [2,2])
+    (declare-input  B float32 [1])
+    (declare-hidden H float32 [1,2])
+    (declare-output Y float32 [1])
 )
 (declare-network g
-    (declare-input C Real [2,2])
-    (declare-output Z Real [1])
+    (declare-input  C float32 [2,2])
+    (declare-output Z float32 [1])
 )
 ...
 \end{lstlisting}
@@ -173,16 +173,17 @@ and the verifier should be able to report the following capabilities:
 \end{lstlisting}
 
 \clOutputOption
-{--onnx-types}
+{--onnx-element-types}
 {Prints a newline-separated list of the element types that the verifier supports. See Section~\ref{sec:element-types} for details.}
 {List of ONNX types}
 \begin{lstlisting}[style=bash]
-%*\exampleVerifier* supports --onnx-types
-real
-float
+%*\exampleVerifier* supports --onnx-element-types
+float64
+float32
 float16
+real
 \end{lstlisting}
-\textbf{Note}: as discussed in Section~\ref{sec:element-types}, if a solver reports that it supports an ONNX element type then there must be a strong reason to believe that the solver's analysis is sound with respect to that type. If it is not sound, or its soundness is unknown then the solver should report that it supports the `real' type.
+\textbf{Note}: as discussed in Section~\ref{sec:element-types}, in order for a solver to report that it supports an ONNX element type, then there must be a strong reason to believe that its analysis is sound with respect to that element type. If unsound, or the soundness is unknown then the solver should only report that it supports the `real' type.
 
 \clOutputOption
 {--onnx-operators}

--- a/document/main.bbl
+++ b/document/main.bbl
@@ -2,9 +2,16 @@
 
 \bibitem{forsberg2005labelled}
 Markus Forsberg and Aarne Ranta.
-\newblock The labelled bnf grammar formalism.
+\newblock The labelled {BNF} grammar formalism.
 \newblock {\em Department of Computing Science, Chalmers University of
   Technology and the University of Gothenburg}, 2005.
+
+\bibitem{jia2021exploiting}
+Kai Jia and Martin Rinard.
+\newblock Exploiting verified neural networks via floating point numerical
+  error.
+\newblock In {\em International Static Analysis Symposium}, pages 191--205.
+  Springer, 2021.
 
 \bibitem{szegedy2013intriguing}
 Christian Szegedy, Wojciech Zaremba, Ilya Sutskever, Joan Bruna, Dumitru Erhan,


### PR DESCRIPTION
Fixes #92.

Also used `float` in preference to `Real` as the default type in the examples.