### PR TITLE
add documentation on initialized keyword

### DIFF
--- a/document/chapters/introduction.tex
+++ b/document/chapters/introduction.tex
@@ -36,6 +36,7 @@ This document uses semantic versioning of the form \texttt{major.minor}. Minor v
 \item Clarified that all model inputs and outputs must be declared in a network declaration, even if the query does not constrain their value.
 \item Clarified that dynamic dimensions in ONNX models must be instantiated with concrete values in the \vnnlib{} query.
 \item Renamed `networkOutputs' function in the definition of a network theory to the more appropriate `modelOutputs'.
+\item Added a \texttt{initialized} keyword to constrain declared inputs to their default value specified in the ONNX model graph initializers.
 \end{itemize}
 
 \subsection*{Changelog for v2.0}

--- a/document/chapters/models.tex
+++ b/document/chapters/models.tex
@@ -109,32 +109,32 @@ This allows the ONNX standard to evolve independently without requiring the expl
 One of the consequences of this parameterisation is that when discussing the semantics of a particular \vnnlib{} query, it is necessary to state the versions of both the ONNX standard and the \vnnlib{} standard being used.
 
 
-\begin{figure}	
-	\newcommand{\grammarShrink}{\vspace{-0.4em}}
-	
-	\begin{subfigure}{\textwidth}
+\begin{figure}
+	\setlength{\grammarparsep}{0pt}
+
+	\begin{subfigure}[t]{0.63\textwidth}
 		\input{diagrams/network-theory-types.tex}
-		\vspace{-0.7em}
 		\caption{Abstract grammar for network model types.}
 		\label{fig:onnx-type-syntax}
 	\end{subfigure}
-	\\
-	\\
-	\\
-	\begin{subfigure}{\textwidth}
+	\begin{subfigure}[t]{0.36\textwidth}
 		\input{diagrams/network-theory-expr.tex}
-		\vspace{0.3em}
-		\caption{Abstract grammar and functions for network models.}
+		\caption{Abstract grammar for network models.}
 		\label{fig:onnx-expr-syntax}
 	\end{subfigure}
-	\\
-	\begin{subfigure}{\textwidth}
+	\begin{subfigure}[t]{\textwidth}
 		\input{diagrams/network-theory-typing-rules.tex}
 		\caption{Abstract type system for network models.}
 		\label{fig:onnx-types}
 	\end{subfigure}
-	\\
-	\begin{subfigure}{\textwidth}
+	\begin{subfigure}[t]{\textwidth}
+		\vspace{-1em}
+		\input{diagrams/network-theory-functions.tex}
+		\vspace{-2em}
+		\caption{Functions for network models.}
+		\label{fig:onnx-func-syntax}
+	\end{subfigure}
+	\begin{subfigure}[t]{\textwidth}
 		\input{diagrams/network-theory-semantics.tex}
 		\caption{Abstract semantics for network models.}
 		\label{fig:onnx-semantics}
@@ -159,13 +159,9 @@ Figures~\ref{fig:onnx-type-syntax}~\&~\ref{fig:onnx-expr-syntax} describe the sy
 \begin{itemize}
 \item In ONNX: the \texttt{ModelProto} object.
 \end{itemize}
-\item $\mgrammar{<nodeOutput>}$ - the format used to reference the outputs of nodes
+\item $\mgrammar{<valueId>}$ - the format used to reference values within a model, such as the outputs of nodes or model inputs, outputs, or initializers
 \begin{itemize}
 	\item In ONNX: any string compliant with the C90 identifier syntax rules.
-\end{itemize}
-\item $\outputNodesFn$ - a function that maps a model to its list of its final outputs
-\begin{itemize}
-	\item In ONNX: the accessor \texttt{model.graph.output}.
 \end{itemize}
 \end{enumerate}
 Figure~\ref{fig:onnx-types} describes the required typing judgments over the syntax, with the interface requiring the definition of:
@@ -173,8 +169,23 @@ Figure~\ref{fig:onnx-types} describes the required typing judgments over the syn
 \item \textsc{(Element)} - a judgement that a numeric string~$\elementVar$ is a valid element of a provided element type~$\elementTypeVar$. For example, it would be expected that the number~`1' could be judged as of type \texttt{float64} and \texttt{int32}, and `1.0' could be judged as of type \texttt{float64} but not \texttt{int32}.
 \item \textsc{(Tensor)} - a judgement that a tensor~$\tensorVar$ is of a given element type and shape~$\tensorTypeVar$.
 \item \textsc{(Model)} - a judgment that a model~$\modelVar$ is of a given type~$\modelTypeVar$, i.e takes in a list of tensors of the provided shape and produces a list of output tensors of the required shapes.
-\item \textsc{(NodeOutput)} - a judgment that a model~$\modelVar$ has a node that produces some tensor called~$\onnxNameVar$ of type~$\tensorTypeVar$ as output.
+\item \textsc{(NamedValue)} - a judgment that a model~$\modelVar$ has a value called~$\onnxNameVar$ of type~$\tensorTypeVar$, either as an output to a node or an initializer.
 \item \textsc{(Isomorphic)} - a judgment that the graph structure of two models are isomorphic to each other. See Section~\ref{sec:multiple-network} for details.
+\end{enumerate}
+Figure~\ref{fig:onnx-func-syntax} describes the functions over the syntax, with the interface requiring the definition of:
+\begin{enumerate}
+\item $\inputNodesFn$ - a function that maps a model to its list of its inputs
+\begin{itemize}
+	\item In ONNX: the accessor \texttt{model.graph.input}.
+\end{itemize}
+\item $\outputNodesFn$ - a function that maps a model to its list of its final outputs
+\begin{itemize}
+	\item In ONNX: the accessor \texttt{model.graph.output}.
+\end{itemize}
+\item $\initializerFn$ - a function that maps a model and a value identifier to a pre-defined value
+\begin{itemize}
+	\item In ONNX: the accessor \texttt{model.graph.initializer}.
+\end{itemize}
 \end{enumerate}
 Finally, Figure~\ref{fig:onnx-semantics} describes the semantics over the well-typed syntactic models, with the interface requiring the definition of:
 \begin{enumerate}

--- a/document/chapters/query_language.tex
+++ b/document/chapters/query_language.tex
@@ -144,7 +144,24 @@ This feature is not currently planned as it (a) would not increase the expressiv
 
 \subsubsection{Inputs with initializers}
 
-Inputs must still be listed even if the model has a corresponding initializer containing a default value for that input. Currently there is no way to specify that the input should use that default value, and instead the input must be constrained to equal that value using standard equality assertions.
+In the ONNX IR specification, an initializer with the same name as an input acts as a default value for that input. In VNNLIB inputs must be listed even if the model has a corresponding initializer in the ONNX model graph. By default, a declared input is not constrained, even if an initializer exists in the model. However, the user can choose to constrain the input to be equal to the default value by including assertions that constrain the variable to be equal to the initializer value.
+
+To simplify the process of constraining an input to be equal to its initializer value, the \texttt{declare-input} declaration can be extended with an optional \texttt{initialized} tag, as shown in \ref{fig:initialized-inputs}. The \texttt{initialized} keyword indicates that a declared input variable should be constrained to be equal to the initializer value given for the corresponding input in the ONNX model graph. It is equivalent to using assertions to constrain the input to be equal to the initializer value, but offers at least 2 major benefits. First, it significantly reduces the verbosity of the specification, particularly since the default value is already specified in the ONNX model. Second, it shifts the specification of the default value to the ONNX model, where it is already defined, meaning the same specification can be used for models that use different values for the initializer, as long as their input/output interfaces are otherwise the same.
+
+\begin{figure}[t]
+    \centering
+    \begin{lstlisting}[style=lbnf]
+(declare-network multi_io_net
+    (declare-input  image    float32 [1,3,224,224])
+    (declare-input  metadata float32 [1,10] initialized)
+    (declare-output bbox     int16   [1 4])
+    (declare-output logits   float32 [1,1000])
+)\end{lstlisting}
+    \caption{A network declaration that specifies that an input should be constrained to its default value.}
+    \label{fig:initialized-inputs}
+\end{figure}
+
+The \texttt{initialized} keyword should only be applied to input declarations and restricts the model interface to ONNX models which specify default values for the corresponding input.
 
 
 \subsubsection{Hidden node declarations}

--- a/document/chapters/query_language.tex
+++ b/document/chapters/query_language.tex
@@ -137,6 +137,7 @@ As will be described more formally in Section~\ref{sec:model-typing}, the declar
 \begin{enumerate}
     \item the network declaration must include all inputs and outputs present in the model even if a particular input or output is not constrained by assertions later in the query.
     \item the inputs and outputs must appear in the same order they are declared in the model.
+    \item any input marked as \texttt{initialized} must have a corresponding initializer in the ONNX model.
 \end{enumerate}
 Note that there has been extensive discussion about extending the standard to allow network inputs and outputs to be referred to by the textual name given to them in the ONNX model. 
 If implemented, this would allow inputs and outputs to be omitted from the network declaration if the user did not wish to constrain them. 
@@ -443,15 +444,13 @@ Given a list of network declarations $\networkDeclSet$, a set of models $\networ
 \begin{equation*}
 \assertEnv (\networkDeclSet, \networkImplementationSet, \networkInputSet) = \bigcup_{\networkDeclVar \in \networkDeclSet} \assertEnv (\networkDeclVar, \networkImplementationSet[\field{\networkDeclVar}{name}], \networkInputSet)
 \end{equation*}
-Concretely, given a network declaration~$\networkDeclVar$, and a compatible model~$\networkImplementation$ and input assignment~$\networkInput$, the calculation of the local environment can be defined as follows:
-\begin{align*}
-\assertEnv (\namedNetworkExpansion{\nameVar'}, \networkImplementation, \networkInputSet) =
-\qquad\qquad\qquad\qquad\qquad\qquad
-\\ 
-\bigcup_{i} \assertEnv_{I}(\inputDeclSet_i) \; \cup \;
+Concretely, given a network declaration~$\networkDeclVar$, and a compatible model~$\networkImplementation$ and input assignment~$\networkInputSet$, the calculation of the local environment can be defined as follows:
+\begin{multline*}
+\assertEnv (\namedNetworkExpansion{\nameVar'}, \networkImplementation, \networkInputSet) = \\
+\bigcup_{i} \assertEnv_{I}(\inputDeclSet_i, \inputNodesFn(m)_i) \; \cup \;
 \bigcup_{i} \assertEnv_{H}(\hiddenDeclSet_i) \; \cup \; 
 \bigcup_{i} \assertEnv_{O}(\outputDeclSet_i, \outputNodesFn(m)_i)
-\end{align*}
+\end{multline*}
 where
 \newcommand{\nameFn}[1]{\text{name}(#1)}
 \newcommand{\hiddenNameFn}[1]{\text{hiddenName}(#1)}
@@ -460,8 +459,13 @@ where
     \sem{\networkInput} 
     &= \{\semTensorTheory{\networkInputSet[\field{\inputDeclVar}{name}]} \mid \inputDeclVar \in \inputDeclSet \}
     \\
-    \assertEnv_{\inputDeclSet}(\inputExpansion) 
-    &= \{ \nameVar \rightarrow \semTensorTheory{\networkInputSet[\nameVar]} \}
+    \assertEnv_{\inputDeclSet}(\inputExpansion, \onnxNameVar) 
+    &= \{ \nameVar \rightarrow
+    \begin{cases}
+        \semTensorTheory{\networkInputSet[\nameVar]} &\text{ if } \neg\iota\\
+        \initializerFn(\networkImplementation, \onnxNameVar) &\text{ if } \iota
+    \end{cases}
+    \}
     \\
     \assertEnv_{\hiddenDeclSet}(\hiddenExpansion) 
     &= \{ \nameVar \rightarrow \semModelTheory{\networkImplementation}(\sem{\networkInput}, \onnxNameVar) \}
@@ -528,7 +532,6 @@ Using the \inlinevnn{real} type gives the solver explicit permission to interpre
     \centering
 	\begin{subfigure}{\textwidth}
 		\input{diagrams/real-network-theory-syntax-types.tex}
-        \vspace{-0.75em}
 		\caption{Grammar for real network model types.}
 		\label{fig:real-theory-type-syntax}
 	\end{subfigure}
@@ -536,7 +539,6 @@ Using the \inlinevnn{real} type gives the solver explicit permission to interpre
 
     \begin{subfigure}{\textwidth}
 		\input{diagrams/real-network-theory-syntax-expr.tex}
-        \vspace{-0.55em}
 		\caption{Grammar and functions for real network model expressions.}
 		\label{fig:real-theory-expr-syntax}
 	\end{subfigure}

--- a/document/diagrams/network-theory-expr.tex
+++ b/document/diagrams/network-theory-expr.tex
@@ -1,20 +1,3 @@
-% \begin{minipage}[t]{0.55\textwidth}
-% 	\setlength{\grammarindent}{9em}
-% 	\begin{grammar}	
-% 	<element> $\ni \elementVar$ ::= (-)[0-9]$^+$(.[0-9]$^+$)
-
-% 	<namedValue> $\ni \onnxNameVar$ ::= \missing
-% 	\end{grammar}
-% \end{minipage}
-% \hfill
-% \begin{minipage}[t]{0.4\textwidth}
-% 	\setlength{\grammarindent}{5.5em}
-% 	\begin{grammar}	
-% 	<tensor> $\ni \tensorVar$ ::= \missing
-	
-% 	<model> $\ni \modelVar$ ::= \missing
-% 	\end{grammar}
-% \end{minipage}
 \begin{minipage}[t]{\textwidth}
 	\setlength{\grammarindent}{7em}
 	\begin{grammar}

--- a/document/diagrams/network-theory-expr.tex
+++ b/document/diagrams/network-theory-expr.tex
@@ -1,22 +1,30 @@
-\begin{minipage}[t]{0.55\textwidth}
-	\setlength{\grammarindent}{8.7em}
-	\begin{grammar}	
-	<element> $\ni \elementVar$ ::= (-)[0-9]$^+$(.[0-9]$^+$)
-	\grammarShrink
+% \begin{minipage}[t]{0.55\textwidth}
+% 	\setlength{\grammarindent}{9em}
+% 	\begin{grammar}	
+% 	<element> $\ni \elementVar$ ::= (-)[0-9]$^+$(.[0-9]$^+$)
 
-	<nodeOutput> $\ni \onnxNameVar$ ::= \missing
-	\end{grammar}
-\end{minipage}
-\begin{minipage}[t]{0.5\textwidth}
-	\setlength{\grammarindent}{6em}
-	\begin{grammar}	
-	<tensor> $\ni \tensorVar$ ::= \missing
-	\grammarShrink
+% 	<namedValue> $\ni \onnxNameVar$ ::= \missing
+% 	\end{grammar}
+% \end{minipage}
+% \hfill
+% \begin{minipage}[t]{0.4\textwidth}
+% 	\setlength{\grammarindent}{5.5em}
+% 	\begin{grammar}	
+% 	<tensor> $\ni \tensorVar$ ::= \missing
 	
-	<model> $\ni \modelVar$ ::= \missing
+% 	<model> $\ni \modelVar$ ::= \missing
+% 	\end{grammar}
+% \end{minipage}
+\begin{minipage}[t]{\textwidth}
+	\setlength{\grammarindent}{7em}
+	\begin{grammar}
+	<model> $\ni \makebox[1em][c]{$\modelVar$}$ ::= \missing
+
+	<valueId> $\ni \makebox[1em][c]{$\onnxNameVar$}$ ::= \missing
+
+	<tensor> $\ni \makebox[1em][c]{$\tensorVar$}$ ::= \missing
+
+	<element> $\ni \makebox[1em][c]{$\elementVar$}$ ::= \\
+		\mbox{(-)[0-9]$^+$(.[0-9]$^+$)}
 	\end{grammar}
 \end{minipage}
-
-\vspace{0.6em}
-$\outputNodesFn : \mgrammar{<model>} \rightarrow \mgrammar{<nodeOutput>}^+$ = \missing
-

--- a/document/diagrams/network-theory-functions.tex
+++ b/document/diagrams/network-theory-functions.tex
@@ -1,0 +1,5 @@
+\begin{flalign*}
+&\inputNodesFn &&:\, \mgrammar{<model>} \rightarrow \mgrammar{<valueId>}^+ &= \missing & \\
+&\outputNodesFn &&:\, \mgrammar{<model>} \rightarrow \mgrammar{<valueId>}^+ &= \missing & \\
+&\initializerFn &&:\, \mgrammar{<model>} \rightarrow \mgrammar{<valueId>} \rightarrow \mgrammar{<tensor>} &= \missing &
+\end{flalign*}

--- a/document/diagrams/network-theory-types.tex
+++ b/document/diagrams/network-theory-types.tex
@@ -1,13 +1,12 @@
-\setlength{\grammarindent}{9em}
+\begin{minipage}[t]{\textwidth}
+\setlength{\grammarindent}{8.5em}
 \begin{grammar}	
 	<elementType> $\ni \elementTypeVar$ ::= \missing
-	\grammarShrink
 
-	<shape> $\ni \shapeVar$ ::= [$n$,...,$n$] \hspace{5em} where $n \in \mathbb{N}$ 
-	\grammarShrink
+	<shape> $\ni \shapeVar$ ::= [$i$,...,$i$] \hspace{0.5em} where $i \in \mathbb{N}$ 
 
 	<tensorType> $\ni \tensorTypeVar$ ::= <elementType>  $\times$ <shape>
-	\grammarShrink
 	
-	<modelType> $\ni \modelTypeVar$ ::= <tensorType>$^+$ $\times$ <tensor-type>$^+$
+	<modelType> $\ni \modelTypeVar$ ::= \\ <tensorType>$^+$ $\times$ <tensorType>$^+$
 \end{grammar}
+\end{minipage}

--- a/document/diagrams/network-theory-typing-rules.tex
+++ b/document/diagrams/network-theory-typing-rules.tex
@@ -1,35 +1,36 @@
-% This minipage exists to force left-alignment
-\begin{minipage}[t]{0.5\textwidth}
-	\begin{flalign*}
-		\inferrule*[Right=(Element)]{
-            \missing
-        }{
-            \vdash \elementVar : \elementTypeVar
-        }
-        \hspace{8.3em}
-        \inferrule*[Right=(Tensor)]{
-            \missing 
-        }{
-            \vdash \tensorVar : \tensorTypeVar
-        }
-        \hspace{7.8em}
-	    \inferrule*[Right=(Model)]{
-            \missing
-        }{
-            \vdash \modelVar : \modelTypeVar 
-        }
-        \\
-        \inferrule*[Right=(NodeOutput)]{
-            \missing
-        }{
-            \modelVar \vdash \onnxNameVar : \tensorTypeVar
-        }
-        \hspace{9em}
-        \inferrule*[Right=(Isomorphic)]{
-            \missing
-        }{
-            \vdash \modelVar_1 \cong \modelVar_2
-        }
-        \hspace{5em}
-    \end{flalign*}
-\end{minipage}
+{
+\vspace{-1em}
+\renewcommand{\MathparLineskip}{\lineskiplimit=0em\lineskip=0em}
+\begin{mathpar}
+    \inferrule*[right=(Element)]{
+        \missing
+    }{
+        \vdash \elementVar : \elementTypeVar
+    }
+    \and
+    \inferrule*[right=(Tensor)]{
+        \missing 
+    }{
+        \vdash \tensorVar : \tensorTypeVar
+    }
+    \and
+    \inferrule*[right=(Model)]{
+        \missing
+    }{
+        \vdash \modelVar : \modelTypeVar 
+    }
+    \and
+    \inferrule*[right=(NamedValue)]{
+        \missing
+    }{
+        \modelVar \vdash \onnxNameVar : \tensorTypeVar
+    }
+    \and
+    \inferrule*[right=(Isomorphic)]{
+        \missing
+    }{
+        \vdash \modelVar_1 \cong \modelVar_2
+    }
+\end{mathpar}
+\vspace{-2em}
+}

--- a/document/diagrams/real-network-theory-grammar.tex
+++ b/document/diagrams/real-network-theory-grammar.tex
@@ -30,7 +30,7 @@
     \end{equation*}
     \spacing
     \begin{equation*}
-        \inferrule*[Right=(NodeOutput$^\real$)]{
+        \inferrule*[Right=(NamedValue$^\real$)]{
             \modelVar \vdash\networkTheoryVarParam \onnxNameVar : \tensorTypeVar'
             \\
             \text{shape}(\tensorTypeVar') = \text{shape}(\tensorTypeVar)

--- a/document/diagrams/real-network-theory-syntax-expr.tex
+++ b/document/diagrams/real-network-theory-syntax-expr.tex
@@ -1,7 +1,11 @@
-\begin{center}
-    \begin{grammar}
-    <tensor> \realParam{} = $(\shapeVar, \real^\shapeVar)$
-    \qquad \qquad 
-    <model> \realParam{} = <model> \hspace{-0.25em}$\networkTheoryVarParam$
-    \end{grammar}
-\end{center}
+\begin{minipage}{0.30\textwidth}
+\begin{grammar}
+<tensor> \realParam{} = $(\shapeVar, \real^\shapeVar)$
+\end{grammar}
+\end{minipage}
+\hfill
+\begin{minipage}{0.35\textwidth}
+\begin{grammar}
+<model> \realParam{} = <model>$\networkTheoryVarParam$
+\end{grammar}
+\end{minipage}

--- a/document/diagrams/real-network-theory-syntax-types.tex
+++ b/document/diagrams/real-network-theory-syntax-types.tex
@@ -1,5 +1,11 @@
+\begin{minipage}{0.30\textwidth}
 \begin{grammar}
 <elementType> \realParam{} = \texttt{real}
-\qquad \qquad 
-<nodeOutput> \realParam{} = <nodeOutput>$\networkTheoryVarParam$
 \end{grammar}
+\end{minipage}
+\hfill
+\begin{minipage}{0.35\textwidth}
+\begin{grammar}
+<valueId> \realParam{} = <valueId>$\networkTheoryVarParam$
+\end{grammar}
+\end{minipage}

--- a/document/diagrams/typing-rule-inputAssignment-inputDecl.tex
+++ b/document/diagrams/typing-rule-inputAssignment-inputDecl.tex
@@ -1,5 +1,5 @@
 \begin{equation*}
-    \inferrule*[Right=InputAssignment]
+    \inferrule*[right=InputAssignment]
     {
         {\begin{array}{c}
             \networkInputSet[\nameVar] \vdash_\networkTheoryVar (\elementTypeVar, \shapeVar)

--- a/document/diagrams/typing-rule-inputAssignment-query.tex
+++ b/document/diagrams/typing-rule-inputAssignment-query.tex
@@ -1,13 +1,9 @@
 \begin{equation*}
-    \inferrule*[Right=InputAssignmentQuery]
+    \inferrule*[right=InputAssignmentQuery]
     {
         \forall \networkDeclVar \in \networkDeclSet \; . \; \forall \inputDeclVar \in \field{\networkDeclVar}{inputs} \; . \; \networkInputSet \vdash \inputDeclVar
     }
     {
         \networkInputSet \vdash \queryExpansion
     }
-    \qquad
-    \qquad
-    \qquad
-    \qquad
 \end{equation*}

--- a/document/diagrams/typing-rule-network-equal.tex
+++ b/document/diagrams/typing-rule-network-equal.tex
@@ -3,7 +3,7 @@
     {
         \assertCtx[v] = \networkExpansion \qquad e = \text{`'}
         \\
-        \forall i . \: \field{\inputDeclSet_i}{shape} = \field{\inputDeclSet'_i}{shape} \wedge \field{\inputDeclSet_i}{type} = \field{\inputDeclSet'_i}{type}
+        \forall i . \: \field{\inputDeclSet_i}{shape} = \field{\inputDeclSet'_i}{shape} \wedge \field{\inputDeclSet_i}{type} = \field{\inputDeclSet'_i}{type} \wedge \field{\inputDeclSet_i}{initialized} = \field{\inputDeclSet'_i}{initialized}
         \\
         \forall i . \: \field{\outputDeclSet_i}{shape} = \field{\outputDeclSet'_i}{shape} \wedge \field{\outputDeclSet_i}{type} = \field{\outputDeclSet'_i}{type}
         \\

--- a/document/diagrams/vnnlib-syntax.tex
+++ b/document/diagrams/vnnlib-syntax.tex
@@ -9,7 +9,7 @@
 	
 	<equiv> ::= (\texttt{equal-to} <name>) | (\texttt{isomorphic-to} <name>)
 	
-	<input> ::= (\texttt{declare-input} <name> <elementType>$\networkTheoryVarParam$ <shape>)
+	<input> ::= (\texttt{declare-input} <name> <elementType>$\networkTheoryVarParam$ <shape> <initialized>$^?$)
 	
 	<hidden> ::= (\texttt{declare-hidden} <name> <elementType>$\networkTheoryVarParam$ <shape> <nodeOutput>$\networkTheoryVarParam$)
 	

--- a/document/diagrams/vnnlib-syntax.tex
+++ b/document/diagrams/vnnlib-syntax.tex
@@ -3,15 +3,17 @@
 	
 	<version> ::= (\texttt{vnnlib-version} \texttt{\textless}[0-9]$^+$.[0-9]$^+$\texttt{\textgreater})
 	
-	<name> ::= [A-Za-z][\_A-Za-z0-9]*
+	<name> ::= [A-Za-z][\_A-Za-z0-9]$^*$
 		
 	<network> ::= (\texttt{declare-network} <name> <equiv>$^?$ <input>$^+$ <hidden>* <output>$^+$)
 	
 	<equiv> ::= (\texttt{equal-to} <name>) | (\texttt{isomorphic-to} <name>)
 	
-	<input> ::= (\texttt{declare-input} <name> <elementType>$\networkTheoryVarParam$ <shape> <initialized>$^?$)
+	<input> ::= (\texttt{declare-input} <name> <elementType>$\networkTheoryVarParam$ <shape> <init>$^?$)
+
+	<init> ::= \texttt{initialized}
 	
-	<hidden> ::= (\texttt{declare-hidden} <name> <elementType>$\networkTheoryVarParam$ <shape> <nodeOutput>$\networkTheoryVarParam$)
+	<hidden> ::= (\texttt{declare-hidden} <name> <elementType>$\networkTheoryVarParam$ <shape> <valueId>$\networkTheoryVarParam$)
 	
 	<output> ::= (\texttt{declare-output} <name> <elementType>$\networkTheoryVarParam$ <shape>)
 	

--- a/document/standard.tex
+++ b/document/standard.tex
@@ -101,9 +101,13 @@
 \newcommand{\elementTypeVar}{\tau}
 \newcommand{\tensorTypeVar}{\delta}
 \newcommand{\modelTypeVar}{\gamma}
+\newcommand{\initVar}{\iota}
 
-\newcommand{\inputNodesFn}{inputs}
+
+\newcommand{\inputNodesFn}{\text{modelInputs}}
+\newcommand{\initNodesFn}{\text{modelInitializers}}
 \newcommand{\outputNodesFn}{\text{modelOutputs}}
+\newcommand{\initializerFn}{\text{modelInitializerValue}}
 
 \newcommand{\semApp}[2]{\sem{#2}_\text{#1}}
 \newcommand{\semElementType}[1]{\semApp{elementType}{#1}}
@@ -173,7 +177,8 @@
 \texttt{declare-input} ~
 \nameVar ~
 \elementTypeVar ~
-\shapeVar
+\shapeVar ~
+\initVar
 }
 
 \newcommand{\hiddenExpansion}


### PR DESCRIPTION
Adds the `initialized` keyword to the standards doc, as discussed in #164.