### PR TITLE
Fix naming of `real` in examples

### DIFF
--- a/syntax/test/acc.vnnlib
+++ b/syntax/test/acc.vnnlib
@@ -1,8 +1,8 @@
 (vnnlib-version <2.0>)
 
 (declare-network acc
-	(declare-input X Real [3])
-	(declare-output Y Real [])
+	(declare-input X real [3])
+	(declare-output Y real [])
 )
 
 (assert (<= (* -1.0 X[0]) 0.0))

--- a/syntax/test/cartpole.vnnlib
+++ b/syntax/test/cartpole.vnnlib
@@ -2,8 +2,8 @@
 ; cartpole property unsafe_44
 
 (declare-network cartpole
-    (declare-input X Real [4])
-    (declare-output Y Real [2])
+    (declare-input X real [4])
+    (declare-output Y real [2])
 )
 
 

--- a/syntax/test/drones.vnnlib
+++ b/syntax/test/drones.vnnlib
@@ -1,7 +1,7 @@
 (vnnlib-version <2.0>)
 (declare-network drones
-	(declare-input X Real [12])
-	(declare-output Y Real [])
+	(declare-input X real [12])
+	(declare-output Y real [])
 )
 
 

--- a/syntax/test/dubinsrejoin.vnnlib
+++ b/syntax/test/dubinsrejoin.vnnlib
@@ -2,8 +2,8 @@
 ; dubinsrejoin property safe_6
 
 (declare-network dubinsrejoin
-	(declare-input X Real [8])
-	(declare-output Y Real [8])
+	(declare-input X real [8])
+	(declare-output Y real [8])
 )
 
 

--- a/syntax/test/initialized.vnnlib
+++ b/syntax/test/initialized.vnnlib
@@ -1,8 +1,8 @@
 (vnnlib-version <2.1>)
 
 (declare-network AcasXu
-	(declare-input A Real [5] initialized)
-	(declare-output B Real [5])
+	(declare-input A real [5] initialized)
+	(declare-output B real [5])
 )
 
 (assert (<= B[3] 0.5))

--- a/syntax/test/intermediate_nodes.vnnlib
+++ b/syntax/test/intermediate_nodes.vnnlib
@@ -1,8 +1,8 @@
 (vnnlib-version <2.0>)
 (declare-network acc 
-	(declare-input X Real [3])
-	(declare-hidden N Real [1,2] "onnx")
-	(declare-output Y Real [3])
+	(declare-input X real [3])
+	(declare-hidden N real [1,2] "onnx")
+	(declare-output Y real [3])
 )
 
 (assert (<= (* -1.0 X[0]) 0.0))

--- a/syntax/test/lunarlander.vnnlib
+++ b/syntax/test/lunarlander.vnnlib
@@ -2,8 +2,8 @@
 ; lunarlander property safe_80
 
 (declare-network lunarlander
-    (declare-input X Real [8])
-    (declare-output Y Real [4])
+    (declare-input X real [8])
+    (declare-output Y real [4])
 )
 
 

--- a/syntax/test/mnist.vnnlib
+++ b/syntax/test/mnist.vnnlib
@@ -1,7 +1,7 @@
 (vnnlib-version <2.0>)
 (declare-network mnist
-	(declare-input X Real [28,28])
-	(declare-output Y Real [10])
+	(declare-input X real [28,28])
+	(declare-output Y real [10])
 )
 
 (assert (>= X[0,0] 0.0))

--- a/syntax/test/multiple_networks.vnnlib
+++ b/syntax/test/multiple_networks.vnnlib
@@ -1,19 +1,19 @@
 (vnnlib-version <2.0>)
 (declare-network AcasXu
-	(declare-input A Real [5])
-	(declare-output B Real [5])
+	(declare-input A real [5])
+	(declare-output B real [5])
 )
 
 (declare-network AcasYu
 	(equal-to AcasXu)
-	(declare-input C Real [5])
-	(declare-output D Real [5])
+	(declare-input C real [5])
+	(declare-output D real [5])
 )
 
 (declare-network AcasZu
 	(isomorphic-to AcasXu)
-	(declare-input E Real [5])
-	(declare-output F Real [5])
+	(declare-input E real [5])
+	(declare-output F real [5])
 )
 
 ; Unscaled Input 0: (55947.691, 60760)

--- a/syntax/test/single_network.vnnlib
+++ b/syntax/test/single_network.vnnlib
@@ -1,7 +1,7 @@
 (vnnlib-version <2.0>)
 (declare-network acc 
-	(declare-input X Real [3])
-	(declare-output Y Real [4])
+	(declare-input X real [3])
+	(declare-output Y real [4])
 )
 
 (assert (<= (* -1.0 X[0]) 0.0))

--- a/syntax/test/test_linearise.vnnlib
+++ b/syntax/test/test_linearise.vnnlib
@@ -4,8 +4,8 @@
 ; This file covers various edge cases to ensure correctness and robustness.
 
 (declare-network test
-    (declare-input X Real [3])
-    (declare-output Y Real [])
+    (declare-input X real [3])
+    (declare-output Y real [])
 )
 
 ; --- GROUP 1: Basic Operations & Constants ---


### PR DESCRIPTION
This was a bug.